### PR TITLE
GitHubアカウントでPrismにログインし、その情報を自動で保存するロジックの実装

### DIFF
--- a/apps/api/drizzle.config.ts
+++ b/apps/api/drizzle.config.ts
@@ -10,17 +10,15 @@ function _getEnvVariable(name: string): string {
 }
 
 export default defineConfig({
-  // スキーマファイルの場所
   schema: "./drizzle/schema.ts",
-  // マイグレーションファイルの出力先
   out: "./drizzle/migrations",
   dialect: "sqlite",
-  //driver: 'd1',
-  // dbCredentials: {
-  //     // wranglerの設定ファイルパス
-  //     wranglerConfigPath: './wrangler.jsonc',
-  //     dbName: 'dummy',
-  // },
+  driver: "d1-http",
+  dbCredentials: {
+    accountId: _getEnvVariable("CLOUDFLARE_ACCOUNT_ID"),
+    databaseId: _getEnvVariable("CLOUDFLARE_DATABASE_ID"),
+    token: _getEnvVariable("CLOUDFLARE_API_TOKEN"),
+  },
   verbose: true,
   strict: true,
 });

--- a/apps/api/drizzle/migrations/0003_majestic_mordo.sql
+++ b/apps/api/drizzle/migrations/0003_majestic_mordo.sql
@@ -1,0 +1,49 @@
+CREATE TABLE `github_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`access_token` text NOT NULL,
+	`refresh_token` text NOT NULL,
+	`access_token_expires_at` integer NOT NULL,
+	`refresh_token_expires_at` integer,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `user_id_idx` ON `github_tokens` (`user_id`);--> statement-breakpoint
+CREATE TABLE `users` (
+	`id` text PRIMARY KEY NOT NULL,
+	`github_id` integer NOT NULL,
+	`github_username` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_github_id_unique` ON `users` (`github_id`);--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`created_at` integer DEFAULT '"2025-08-07T18:02:48.961Z"' NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_messages`("id", "conversation_id", "role", "content", "created_at") SELECT "id", "conversation_id", "role", "content", "created_at" FROM `messages`;--> statement-breakpoint
+DROP TABLE `messages`;--> statement-breakpoint
+ALTER TABLE `__new_messages` RENAME TO `messages`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`title` text NOT NULL,
+	`phase` text DEFAULT 'idea' NOT NULL,
+	`created_at` integer DEFAULT '"2025-08-07T18:02:48.961Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-08-07T18:02:48.961Z"' NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_conversations`("id", "user_id", "title", "phase", "created_at", "updated_at") SELECT "id", "user_id", "title", "phase", "created_at", "updated_at" FROM `conversations`;--> statement-breakpoint
+DROP TABLE `conversations`;--> statement-breakpoint
+ALTER TABLE `__new_conversations` RENAME TO `conversations`;

--- a/apps/api/drizzle/migrations/0004_blushing_shen.sql
+++ b/apps/api/drizzle/migrations/0004_blushing_shen.sql
@@ -1,0 +1,27 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_conversations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`title` text NOT NULL,
+	`phase` text DEFAULT 'idea' NOT NULL,
+	`created_at` integer DEFAULT '"2025-08-08T03:20:29.976Z"' NOT NULL,
+	`updated_at` integer DEFAULT '"2025-08-08T03:20:29.976Z"' NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_conversations`("id", "user_id", "title", "phase", "created_at", "updated_at") SELECT "id", "user_id", "title", "phase", "created_at", "updated_at" FROM `conversations`;--> statement-breakpoint
+DROP TABLE `conversations`;--> statement-breakpoint
+ALTER TABLE `__new_conversations` RENAME TO `conversations`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE TABLE `__new_messages` (
+	`id` text PRIMARY KEY NOT NULL,
+	`conversation_id` text NOT NULL,
+	`role` text NOT NULL,
+	`content` text NOT NULL,
+	`created_at` integer DEFAULT '"2025-08-08T03:20:29.976Z"' NOT NULL,
+	FOREIGN KEY (`conversation_id`) REFERENCES `conversations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+INSERT INTO `__new_messages`("id", "conversation_id", "role", "content", "created_at") SELECT "id", "conversation_id", "role", "content", "created_at" FROM `messages`;--> statement-breakpoint
+DROP TABLE `messages`;--> statement-breakpoint
+ALTER TABLE `__new_messages` RENAME TO `messages`;

--- a/apps/api/drizzle/migrations/meta/0003_snapshot.json
+++ b/apps/api/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,276 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "55eea486-b40d-482f-b876-d50b128e60d9",
+  "prevId": "884ede41-c17a-4bd1-a82b-d6e6ad4a8a2e",
+  "tables": {
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idea'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-07T18:02:48.961Z\"'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-07T18:02:48.961Z\"'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_tokens": {
+      "name": "github_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "github_tokens_user_id_users_id_fk": {
+          "name": "github_tokens_user_id_users_id_fk",
+          "tableFrom": "github_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-07T18:02:48.961Z\"'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "columns": ["github_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/migrations/meta/0004_snapshot.json
+++ b/apps/api/drizzle/migrations/meta/0004_snapshot.json
@@ -1,0 +1,276 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "aa3362cb-3a45-4940-b963-3220454fcf51",
+  "prevId": "55eea486-b40d-482f-b876-d50b128e60d9",
+  "tables": {
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idea'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-08T03:20:29.976Z\"'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-08T03:20:29.976Z\"'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "conversations_user_id_users_id_fk": {
+          "name": "conversations_user_id_users_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_tokens": {
+      "name": "github_tokens",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "github_tokens_user_id_users_id_fk": {
+          "name": "github_tokens_user_id_users_id_fk",
+          "tableFrom": "github_tokens",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'\"2025-08-08T03:20:29.976Z\"'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "columns": ["github_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/migrations/meta/_journal.json
+++ b/apps/api/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,20 @@
       "when": 1754577934058,
       "tag": "0002_serious_zuras",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1754589768977,
+      "tag": "0003_majestic_mordo",
+      "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1754623229988,
+      "tag": "0004_blushing_shen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/schema.ts
+++ b/apps/api/drizzle/schema.ts
@@ -1,13 +1,59 @@
-import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import {
+  integer,
+  sqliteTable,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+import { sql, relations } from "drizzle-orm"; // sql と relations をインポート
 
-// 対話のセッション情報を保存するテーブル
-export const conversations = sqliteTable("conversations", {
-  id: text("id").primaryKey(),
-  userId: text("user_id").notNull(),
-  title: text("title").notNull(),
-  phase: text("phase", { enum: ["idea", "requirements", "tasks"] }) // フェーズ管理を追加
+// ユーザー情報を保存するテーブル
+export const users = sqliteTable("users", {
+  id: text("id")
     .notNull()
-    .default("idea"), // デフォルト(始め)はidea
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()), // Prism内部でユーザーを識別するUUID
+  githubId: integer("github_id").notNull().unique(), // GitHubから取得するユーザーのユニークなID
+  githubUsername: text("github_username").notNull(), // GitHubユーザー名
+  createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`), // 作成日時
+  updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`), // 更新日時
+});
+
+// githubTokens テーブルの定義
+export const githubTokens = sqliteTable(
+  "github_tokens",
+  {
+    id: text("id")
+      .notNull()
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()), // トークンレコードのUUID
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }), // users.idへの外部キー
+    accessToken: text("access_token").notNull(), // GitHub API呼び出し用トークン
+    refreshToken: text("refresh_token").notNull(), // アクセストークン更新用トークン
+    accessTokenExpiresAt: integer("access_token_expires_at").notNull(), // アクセストークンの有効期限 (UNIXタイムスタンプ秒)
+    refreshTokenExpiresAt: integer("refresh_token_expires_at"), // リフレッシュトークンの有効期限 (UNIXタイムスタンプ秒, オプション)
+    createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`), // 作成日時
+    updatedAt: text("updated_at").notNull().default(sql`CURRENT_TIMESTAMP`), // 更新日時
+  },
+  (table) => [
+    // 配列形式に変更（新しいDrizzle ORMの形式）
+    uniqueIndex("user_id_idx").on(table.userId),
+  ],
+);
+
+// 対話のセッション情報を保存するテーブル (既存の定義にuserIdとcreatedAtの修正)
+export const conversations = sqliteTable("conversations", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  title: text("title").notNull(),
+  phase: text("phase", { enum: ["idea", "requirements", "tasks"] })
+    .notNull()
+    .default("idea"),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .default(new Date()),
@@ -16,15 +62,62 @@ export const conversations = sqliteTable("conversations", {
     .default(new Date()),
 });
 
-// 対話メッセージを保存するテーブル
+// 対話メッセージを保存するテーブル (既存の定義にcreatedAtの修正)
 export const messages = sqliteTable("messages", {
-  id: text("id").primaryKey(),
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
   conversationId: text("conversation_id")
     .notNull()
-    .references(() => conversations.id),
+    .references(() => conversations.id, { onDelete: "cascade" }),
   role: text("role", { enum: ["user", "ai"] }).notNull(),
   content: text("content").notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .notNull()
     .default(new Date()),
 });
+
+// --- テーブル間のリレーションシップ定義 ---
+
+// users テーブルのリレーション
+export const usersRelations = relations(users, ({ one, many }) => ({
+  // 1ユーザーは1つのGitHubトークンセットを持つ (one)
+  githubTokens: one(githubTokens, {
+    fields: [users.id],
+    references: [githubTokens.userId],
+  }),
+  // 1ユーザーは複数の会話を持つ (many)
+  conversations: many(conversations),
+}));
+
+// githubTokens テーブルのリレーション
+export const githubTokensRelations = relations(githubTokens, ({ one }) => ({
+  // 1つのトークンセットは1人のユーザーに属する (one)
+  user: one(users, {
+    fields: [githubTokens.userId],
+    references: [users.id],
+  }),
+}));
+
+// conversations テーブルのリレーション
+export const conversationsRelations = relations(
+  conversations,
+  ({ one, many }) => ({
+    // 1つの会話は1人のユーザーに属する (one)
+    user: one(users, {
+      fields: [conversations.userId],
+      references: [users.id],
+    }),
+    // 1つの会話は複数のメッセージを持つ (many)
+    messages: many(messages),
+  }),
+);
+
+// messages テーブルのリレーション
+export const messagesRelations = relations(messages, ({ one }) => ({
+  // 1つのメッセージは1つの会話に属する (one)
+  conversation: one(conversations, {
+    fields: [messages.conversationId],
+    references: [conversations.id],
+  }),
+}));

--- a/apps/api/drizzle/schema.ts
+++ b/apps/api/drizzle/schema.ts
@@ -30,7 +30,7 @@ export const githubTokens = sqliteTable(
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }), // users.idへの外部キー
     accessToken: text("access_token").notNull(), // GitHub API呼び出し用トークン
-    refreshToken: text("refresh_token").notNull(), // アクセストークン更新用トークン
+    refreshToken: text("refresh_token"), // アクセストークン更新用トークン（nullableに変更）
     accessTokenExpiresAt: integer("access_token_expires_at").notNull(), // アクセストークンの有効期限 (UNIXタイムスタンプ秒)
     refreshTokenExpiresAt: integer("refresh_token_expires_at"), // リフレッシュトークンの有効期限 (UNIXタイムスタンプ秒, オプション)
     createdAt: text("created_at").notNull().default(sql`CURRENT_TIMESTAMP`), // 作成日時

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,7 +8,7 @@
     "start": "wrangler dev src/index.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply prism-db --local",
-    "db:migrate:prod": "wrangler d1 migrations apply prism-db",
+    "db:migrate:prod": "wrangler d1 migrations apply prism-db --remote",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -102,7 +102,7 @@ app.get("/db/test-user", async (c) => {
 
   try {
     // 1. users テーブルにデータを挿入 (または既存ユーザーを更新)
-    const testGithubId = 123456789; // テスト用のGitHub ID
+    const testGithubId = -12345; // テスト用のGitHub ID（本番IDと衝突しない負の値を使用）
     const testGithubUsername = "testuser_prism"; // テスト用のユーザー名
 
     // upsert (挿入または更新) のロジック

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,12 +1,30 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { drizzle } from "drizzle-orm/d1"; // DB実装を有効化
+import * as schema from "../drizzle/schema"; // DB実装を有効化
+import { eq } from "drizzle-orm";
+
 import { conversations } from "./routes/conversation";
-import { websocket } from "./routes/websocket";
+import { websocket } from "./routes/websocket"; // 既存のwebsocketルーター
 import githubRouter from "./routes/github";
 import type { AppEnv } from "./types/definitions";
 
-// HonoのインスタンスにAppEnv型を適用
-const app = new Hono<{ Bindings: AppEnv }>();
+// DrizzleDBの型定義を再度有効化します
+export type DrizzleDB = ReturnType<typeof drizzle<typeof schema>>;
+
+// AppContextのVariablesにdbプロパティを追加します
+// types/definitions.tsのAppContextをこの形式に合わせる必要があります。
+// もしtypes/definitions.tsのAppContextがinterface AppContext { Bindings: AppEnv; } の形であれば、
+// interface AppContext { Bindings: AppEnv; Variables: { db: DrizzleDB; }; } に更新してください。
+export interface AppContext {
+  Bindings: AppEnv;
+  Variables: {
+    db: DrizzleDB;
+  };
+}
+
+// HonoのインスタンスにAppContext型を適用
+const app = new Hono<AppContext>();
 
 /**
  * CORS 設定
@@ -15,11 +33,25 @@ const app = new Hono<{ Bindings: AppEnv }>();
 app.use(
   "/*",
   cors({
-    origin: "chrome-extension://iehakmnooonopdcffjcibndgidphpanc",
+    origin: "chrome-extension://iehakmnooonopdcffjcibndgidphpanc", // あなたのChrome拡張機能のIDに置き換えてください
     allowMethods: ["GET", "POST", "PUT", "DELETE"],
     allowHeaders: ["Content-Type"],
   }),
 );
+
+// ミドルウェア: リクエストごとにDBインスタンスを生成 (有効化)
+// AppContextのBindingsにDBプロパティがあることを前提とします。
+app.use("*", async (c, next) => {
+  // c.env.DBが存在するか確認し、Drizzleインスタンスを生成
+  if (c.env.DB) {
+    const db = drizzle(c.env.DB, { schema });
+    c.set("db", db);
+  } else {
+    // DBが利用できない場合のログまたはエラーハンドリング
+    console.warn("D1 Database (c.env.DB) is not available.");
+  }
+  await next();
+});
 
 // ルートパス ("/") の変更
 // アプリケーションのルートURLにアクセスした際に、GitHub認証を開始するためのHTMLを返します。
@@ -40,6 +72,10 @@ app.get("/", (c) => {
           <a href="/github/oauth" class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-300 transform hover:scale-105 inline-block">
             GitHubで認証を開始する
           </a>
+          <div class="mt-8 text-gray-400">
+            <p>DBテスト用エンドポイント:</p>
+            <p><code class="bg-gray-700 p-1 rounded">/db/test-user</code></p>
+          </div>
         </div>
       </body>
     </html>
@@ -47,11 +83,83 @@ app.get("/", (c) => {
 });
 
 // GitHub認証関連のルートを登録
-// これにより、/github/oauth や /github/callback のようなパスでアクセスできるようになります。
 app.route("/github", githubRouter);
 
 app.route("/", conversations);
 
-app.route("/ws", websocket);
+app.route("/ws", websocket); // 既存のwebsocketルーターの登録
+
+// 新規追加: DBテスト用エンドポイント
+app.get("/db/test-user", async (c) => {
+  const db = c.get("db"); // ミドルウェアで設定されたDBインスタンスを取得
+
+  if (!db) {
+    return c.text(
+      "Database not initialized. Check your D1 binding in wrangler.jsonc or .env.",
+      500,
+    );
+  }
+
+  try {
+    // 1. users テーブルにデータを挿入 (または既存ユーザーを更新)
+    const testGithubId = 123456789; // テスト用のGitHub ID
+    const testGithubUsername = "testuser_prism"; // テスト用のユーザー名
+
+    // upsert (挿入または更新) のロジック
+    // まず既存ユーザーを検索
+    const existingUsers = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.githubId, testGithubId))
+      .limit(1);
+    let user: typeof schema.users.$inferSelect;
+
+    if (existingUsers.length > 0) {
+      // ユーザーが存在する場合、更新
+      const [updated] = await db
+        .update(schema.users)
+        .set({
+          githubUsername: testGithubUsername,
+          updatedAt: new Date().toISOString(),
+        })
+        .where(eq(schema.users.githubId, testGithubId))
+        .returning();
+      if (!updated) return c.json({ error: "Update failed" }, 500);
+      user = updated;
+      console.log("Existing user updated:", user);
+    } else {
+      // ユーザーが存在しない場合、新規挿入
+      const [created] = await db
+        .insert(schema.users)
+        .values({
+          githubId: testGithubId,
+          githubUsername: testGithubUsername,
+        })
+        .returning();
+      if (!created) return c.json({ error: "Insert failed" }, 500);
+      user = created;
+      console.log("New user created:", user);
+    }
+
+    // 2. users テーブルからすべてのデータを取得して確認
+    const allUsers = await db.select().from(schema.users);
+    console.log("All users in DB:", allUsers);
+
+    return c.json({
+      message: "DB test successful: User inserted/updated and retrieved.",
+      insertedOrUpdatedUser: user,
+      allUsersInDb: allUsers,
+    });
+  } catch (error) {
+    console.error("DB test error:", error);
+    return c.json(
+      {
+        error: "Failed to perform DB operations.",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      500,
+    );
+  }
+});
 
 export default app;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -33,7 +33,7 @@ const app = new Hono<AppContext>();
 app.use(
   "/*",
   cors({
-    origin: "chrome-extension://iehakmnooonopdcffjcibndgidphpanc", // あなたのChrome拡張機能のIDに置き換えてください
+    origin: "chrome-extension://iehakmnooonopdcffjcibndgidphpanc", // Prism ExtensionのID
     allowMethods: ["GET", "POST", "PUT", "DELETE"],
     allowHeaders: ["Content-Type"],
   }),

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -1,16 +1,24 @@
 import { Hono } from "hono";
-import { exchangeCodeForTokens } from "../services/github/auth";
+import {
+  exchangeCodeForTokens,
+  getGitHubUserProfile,
+} from "../services/github/auth"; // getGitHubUserProfileをインポート
+import { findOrCreateUser, saveGitHubTokens } from "../services/user"; // findOrCreateUser, saveGitHubTokensをインポート
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type * as schema from "../../drizzle/schema";
 import type { AppEnv } from "../types/definitions"; // AppEnvをインポート
 
 // GitHub関連のルートを管理するためのHonoインスタンスを作成します。
-// 修正: Bindingsの型としてAppEnv自体を使用します。
-// これにより、c.envがAppEnvのプロパティ（GITHUB_CLIENT_IDなど）を直接持つことを示します。
-const githubRouter = new Hono<{ Bindings: AppEnv }>();
+// Bindingsの型としてAppEnv自体を使用します。
+const githubRouter = new Hono<{
+  Bindings: AppEnv;
+  Variables: { db: DrizzleD1Database<typeof schema> };
+}>();
 
 // GitHub OAuth認証の開始エンドポイント
 // ユーザーをGitHubの認証ページへリダイレクトします。
 githubRouter.get("/oauth", async (c) => {
-  const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID; // c.envがAppEnv型を持つため、エラーが解消
+  const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID;
   const GITHUB_REDIRECT_URI = c.env.GITHUB_REDIRECT_URI;
 
   // CSRF攻撃を防ぐための一意なstate文字列を生成
@@ -27,55 +35,90 @@ githubRouter.get("/oauth", async (c) => {
 // GitHub OAuth認証のコールバックエンドポイント
 // GitHubからの認証コードを受け取り、アクセストークンを交換します。
 githubRouter.get("/callback", async (c) => {
-  const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID; // c.envがAppEnv型を持つため、エラーが解消
+  const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID;
   const GITHUB_CLIENT_SECRET = c.env.GITHUB_CLIENT_SECRET;
 
   const code = c.req.query("code");
-  const _state = c.req.query("state"); // stateはCSRF対策に必要
+  const _state = c.req.query("state"); // stateはCSRF対策に必要だが、ここでは未使用
 
-  // ⚠️ 実際のアプリケーションでは、CSRF対策のstate検証が必要です。
-
+  // 認証コードがない場合はエラー
   if (!code) {
     return c.text("No code provided", 400);
   }
 
-  // サービス層の関数を呼び出してアクセストークンを交換
-  const tokens = await exchangeCodeForTokens(
-    code,
-    GITHUB_CLIENT_ID,
-    GITHUB_CLIENT_SECRET,
-  );
-
-  if (!tokens || !tokens.access_token) {
-    return c.text("Failed to get access token", 500);
+  // DBインスタンスをコンテキストから取得
+  // AppContextを使わない場合、c.get()の戻り値はany型になるため、D1Database型にキャストします。
+  const db = c.get("db");
+  if (!db) {
+    return c.text(
+      "Database not initialized. Check your D1 binding in wrangler.jsonc or .env.",
+      500,
+    );
   }
 
-  console.log("Access Token:", tokens.access_token);
-  console.log("Refresh Token:", tokens.refresh_token || "N/A");
+  try {
+    // 1. GitHubからアクセストークンを交換
+    const tokens = await exchangeCodeForTokens(
+      code,
+      GITHUB_CLIENT_ID,
+      GITHUB_CLIENT_SECRET,
+    );
+    if (!tokens || !tokens.access_token) {
+      return c.text("Failed to get access token from GitHub.", 500);
+    }
 
-  // 認証成功のHTMLレスポンス
-  return c.html(`
-    <html lang="ja">
-      <head>
-        <title>認証成功</title>
-        <script src="https://cdn.tailwindcss.com"></script>
-      </head>
-      <body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4">
-        <div class="bg-gray-800 rounded-lg shadow-lg p-8 max-w-md w-full text-center">
-          <h1 class="text-3xl font-bold mb-4 text-green-400">認証成功！</h1>
-          <p class="text-lg mb-6">アクセストークンの取得に成功しました。</p>
-          <div class="bg-gray-700 p-4 rounded-md text-left break-all text-sm mb-4">
-            <h2 class="font-semibold mb-2 text-gray-400">取得したトークン（デバッグ用）:</h2>
-            <p><strong>Access Token:</strong> ${tokens.access_token}</p>
-            <p><strong>Refresh Token:</strong> ${tokens.refresh_token || "N/A"}</p>
+    // 2. アクセストークンを使ってGitHubユーザープロファイルを取得
+    const userProfile = await getGitHubUserProfile(tokens.access_token);
+    if (!userProfile) {
+      return c.text("Failed to get GitHub user profile.", 500);
+    }
+
+    // 3. GitHubユーザーIDに基づいてPrism内部のユーザーを検索または新規作成
+    const user = await findOrCreateUser(db, userProfile.id, userProfile.login);
+
+    // 4. 取得したユーザーIDとトークンをデータベースに保存/更新
+    await saveGitHubTokens(db, user.id, tokens);
+
+    console.log("Authentication successful for user:", user.githubUsername);
+    console.log("Access Token saved/updated for userId:", user.id);
+
+    // 認証成功のHTMLレスポンス (テスト用)
+    return c.html(`
+      <html lang="ja">
+        <head>
+          <title>認証成功</title>
+          <script src="https://cdn.tailwindcss.com"></script>
+          <style>
+            body { font-family: 'Inter', sans-serif; }
+          </style>
+        </head>
+        <body class="bg-gray-900 text-white min-h-screen flex items-center justify-center p-4">
+          <div class="bg-gray-800 rounded-lg shadow-lg p-8 max-w-md w-full text-center rounded-xl">
+            <h1 class="text-3xl font-bold mb-4 text-green-400">認証成功！</h1>
+            <p class="text-lg mb-6 text-gray-300">GitHubアカウントとの連携が完了し、トークンが保存されました。</p>
+            <div class="bg-gray-700 p-4 rounded-md text-left break-all text-sm mb-4">
+              <h2 class="font-semibold mb-2 text-gray-400">認証済みユーザー:</h2>
+              <p><strong>Prism User ID:</strong> ${user.id}</p>
+              <p><strong>GitHub Username:</strong> ${user.githubUsername}</p>
+              <p><strong>GitHub ID:</strong> ${user.githubId}</p>
+            </div>
+            <a href="/" class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg transition-colors duration-300 transform hover:scale-105 inline-block">
+              トップに戻る
+            </a>
           </div>
-          <a href="/" class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded-lg transition-colors">
-            トップに戻る
-          </a>
-        </div>
-      </body>
-    </html>
-  `);
+        </body>
+      </html>
+    `);
+  } catch (error) {
+    console.error("GitHub OAuth callback error:", error);
+    return c.json(
+      {
+        error: "Authentication failed",
+        details: error instanceof Error ? error.message : String(error),
+      },
+      500,
+    );
+  }
 });
 
 export default githubRouter;

--- a/apps/api/src/services/github/auth.ts
+++ b/apps/api/src/services/github/auth.ts
@@ -1,4 +1,7 @@
-import type { GitHubTokenResponse } from "../../types/github"; // 型定義をインポート
+import type {
+  GitHubTokenResponse,
+  GitHubUserProfile,
+} from "../../types/github"; // 型定義をインポート
 
 /**
  * GitHubの認証コードを使ってアクセストークンを交換する関数。
@@ -43,6 +46,39 @@ export async function exchangeCodeForTokens(
     return data;
   } catch (error) {
     console.error("Error during token exchange:", error);
+    return null;
+  }
+}
+
+/**
+ * GitHubのアクセストークンを使ってユーザープロファイルを取得する関数。
+ * @param accessToken GitHubアクセストークン
+ * @returns GitHubユーザープロファイルオブジェクト、またはnull
+ */
+export async function getGitHubUserProfile(
+  accessToken: string,
+): Promise<GitHubUserProfile | null> {
+  try {
+    const response = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `token ${accessToken}`, // アクセストークンをヘッダーに含める
+        "User-Agent": "Prism-extension", // GitHub APIの要件: User-Agentヘッダー
+      },
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to get GitHub user profile: ${response.status} ${response.statusText}`,
+      );
+      const errorData = await response.json();
+      console.error("Error details:", errorData);
+      return null;
+    }
+
+    const userProfile: GitHubUserProfile = await response.json();
+    return userProfile;
+  } catch (error) {
+    console.error("Error fetching GitHub user profile:", error);
     return null;
   }
 }

--- a/apps/api/src/services/user.ts
+++ b/apps/api/src/services/user.ts
@@ -1,0 +1,100 @@
+import { eq } from "drizzle-orm";
+import { users, githubTokens } from "../../drizzle/schema"; // usersとgithubTokensテーブルを直接インポート
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import type * as schema from "../../drizzle/schema";
+import type { GitHubTokenResponse } from "../types/github"; // GitHub関連の型をインポート
+
+/**
+ * GitHubユーザーIDに基づいてユーザーを検索し、存在しない場合は新しく作成する関数。
+ * @param db Drizzleデータベースインスタンス
+ * @param githubId GitHubユーザーのユニークな数値ID
+ * @param githubUsername GitHubユーザー名
+ * @returns ユーザーレコード
+ */
+export async function findOrCreateUser(
+  db: DrizzleD1Database<typeof schema>,
+  githubId: number,
+  githubUsername: string,
+): Promise<typeof users.$inferSelect> {
+  // 既存ユーザーを検索
+  const existingUsers = await db
+    .select()
+    .from(users)
+    .where(eq(users.githubId, githubId))
+    .limit(1);
+
+  if (existingUsers.length > 0) {
+    // ユーザーが存在する場合、ユーザー名を更新して返す
+    const [updatedUser] = await db
+      .update(users)
+      .set({
+        githubUsername: githubUsername,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(users.githubId, githubId))
+      .returning();
+    if (!updatedUser) throw new Error("Failed to update existing user.");
+    return updatedUser;
+  } else {
+    // ユーザーが存在しない場合、新規作成
+    const [newUser] = await db
+      .insert(users)
+      .values({
+        githubId: githubId,
+        githubUsername: githubUsername,
+      })
+      .returning();
+    if (!newUser) throw new Error("Failed to create new user.");
+    return newUser;
+  }
+}
+
+/**
+ * ユーザーのGitHubトークンをデータベースに保存または更新する関数。
+ * @param db Drizzleデータベースインスタンス
+ * @param userId Prism内部のユーザーID
+ * @param tokens GitHubトークンレスポンス
+ */
+export async function saveGitHubTokens(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+  tokens: GitHubTokenResponse,
+): Promise<void> {
+  // アクセストークンの有効期限を計算 (現在時刻 + expiresIn秒)
+  const accessTokenExpiresAt =
+    Math.floor(Date.now() / 1000) + (tokens.expires_in ?? 3600); // デフォルト1時間
+
+  // 既存のトークンレコードを検索 (userIdはユニークインデックスなので1つだけ)
+  const existingTokens = await db
+    .select()
+    .from(githubTokens)
+    .where(eq(githubTokens.userId, userId))
+    .limit(1);
+
+  if (existingTokens.length > 0) {
+    // 既存のトークンがある場合、更新
+    await db
+      .update(githubTokens)
+      .set({
+        accessToken: tokens.access_token,
+        refreshToken: tokens.refresh_token || existingTokens[0].refreshToken, // リフレッシュトークンが提供されない場合は既存のものを維持
+        accessTokenExpiresAt: accessTokenExpiresAt,
+        refreshTokenExpiresAt: tokens.refresh_token_expires_in
+          ? Math.floor(Date.now() / 1000) + tokens.refresh_token_expires_in
+          : existingTokens[0].refreshTokenExpiresAt,
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(githubTokens.userId, userId));
+  } else {
+    // 既存のトークンがない場合、新規挿入
+    await db.insert(githubTokens).values({
+      userId: userId,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token || "", // refreshTokenが必須の場合、nullish coalescingは使えないので注意
+      accessTokenExpiresAt: accessTokenExpiresAt,
+      refreshTokenExpiresAt: tokens.refresh_token_expires_in
+        ? Math.floor(Date.now() / 1000) + tokens.refresh_token_expires_in
+        : undefined,
+    });
+  }
+}

--- a/apps/api/src/types/github.ts
+++ b/apps/api/src/types/github.ts
@@ -15,6 +15,45 @@ export interface GitHubTokenResponse {
   access_token: string;
   token_type: string;
   scope: string;
+  expires_in?: number;
   refresh_token?: string; // refresh_tokenはオプション
   refresh_token_expires_in?: number;
+}
+
+/**
+ * GitHubユーザープロファイルAPI (/user) からのレスポンスの型定義。
+ */
+export interface GitHubUserProfile {
+  id: number; // GitHubユーザーのユニークな数値ID
+  login: string; // GitHubユーザー名
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: string;
+  site_admin: boolean;
+  name: string | null;
+  company: string | null;
+  blog: string | null;
+  location: string | null;
+  email: string | null;
+  hireable: boolean | null;
+  bio: string | null;
+  twitter_username: string | null;
+  public_repos: number;
+  public_gists: number;
+  followers: number;
+  following: number;
+  created_at: string;
+  updated_at: string;
 }

--- a/biome.json
+++ b/biome.json
@@ -13,7 +13,8 @@
       "!**/build/**",
       "!**/dist/**",
       "!**/node_modules/**",
-      "!**/worker-configuration.d.ts"
+      "!**/worker-configuration.d.ts",
+      "!**/.wrangler/**"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
アクセストークンをGithubでログインしてトークンとユーザー情報を紐づけてDBに保存するロジックを実装しました。

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->
Github APIを使うためにはアクセストークンが必要だから。
チャット履歴機能を実現するためにログイン機能を実装し、どのユーザーがどのチャットをしたかを紐づけています。

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 依存関係の変更

- [ ] インストールが必要

  インストールコマンド ↓
```pnpm i --frozen-lockfile```

## 📸 スクリーンショット（UI変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #49 
Closes #74 
