### PR TITLE
保存されたトークンの取得とリフレッシュ

### DIFF
--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -239,6 +239,7 @@ githubRouter.post("/exchange", async (c) => {
     await saveGitHubTokens(db, user.id, tokens);
 
     return c.json({
+      success: true,
       message: "Authentication successful",
       user: {
         id: user.id,

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -3,7 +3,11 @@ import {
   exchangeCodeForTokens,
   getGitHubUserProfile,
 } from "../services/github/auth"; // getGitHubUserProfileをインポート
-import { findOrCreateUser, saveGitHubTokens } from "../services/user"; // findOrCreateUser, saveGitHubTokensをインポート
+import {
+  findOrCreateUser,
+  saveGitHubTokens,
+  getValidGitHubAccessToken,
+} from "../services/user"; // findOrCreateUser, saveGitHubTokensをインポート
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import type * as schema from "../../drizzle/schema";
 import type { AppEnv } from "../types/definitions"; // AppEnvをインポート
@@ -65,6 +69,48 @@ githubRouter.get("/callback", async (c) => {
     sameSite: "Lax",
     path: "/",
     maxAge: 0,
+  });
+
+  // 新規追加: トークン取得とリフレッシュのテストエンドポイント
+  githubRouter.get("/test-token-refresh", async (c) => {
+    const db = c.get("db");
+    if (!db) return c.text("Database not initialized.", 500);
+
+    const userId = c.req.query("userId"); // テストしたいユーザーのPrism User IDをクエリパラメータで渡す
+    if (!userId) return c.text("User ID is required for testing.", 400);
+
+    const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID;
+    const GITHUB_CLIENT_SECRET = c.env.GITHUB_CLIENT_SECRET;
+
+    try {
+      const validAccessToken = await getValidGitHubAccessToken(
+        db,
+        userId,
+        GITHUB_CLIENT_ID,
+        GITHUB_CLIENT_SECRET,
+      );
+
+      if (validAccessToken) {
+        // 取得したトークンを使ってGitHub APIを呼び出してみる (例: /user API)
+        const userProfile = await getGitHubUserProfile(validAccessToken);
+        return c.json({
+          message: "Successfully got valid access token and user profile.",
+          accessToken: validAccessToken,
+          userProfile: userProfile,
+        });
+      } else {
+        return c.json(
+          {
+            message:
+              "Failed to get a valid access token. User may need to re-authenticate.",
+          },
+          401,
+        );
+      }
+    } catch (error) {
+      console.error("Test token refresh endpoint error:", error);
+      return c.json({ error: "Internal server error during token test." }, 500);
+    }
   });
 
   // 以下、トークン交換へ続行…

--- a/apps/api/src/services/github/auth.ts
+++ b/apps/api/src/services/github/auth.ts
@@ -82,3 +82,50 @@ export async function getGitHubUserProfile(
     return null;
   }
 }
+
+/**
+ * GitHubのリフレッシュトークンを使って新しいアクセストークンを取得する関数。
+ * @param refreshToken ユーザーのリフレッシュトークン
+ * @param clientId GitHub AppのクライアントID
+ * @param clientSecret GitHub Appのクライアントシークレット
+ * @returns 新しいアクセストークンとリフレッシュトークンを含むオブジェクト、またはnull
+ */
+export async function refreshGitHubAccessToken(
+  refreshToken: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<GitHubTokenResponse | null> {
+  try {
+    const response = await fetch(
+      "https://github.com/login/oauth/access_token",
+      {
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          client_id: clientId,
+          client_secret: clientSecret,
+          grant_type: "refresh_token", // リフレッシュトークンフローの指定
+          refresh_token: refreshToken,
+        }),
+      },
+    );
+
+    if (!response.ok) {
+      console.error(
+        `Failed to refresh GitHub access token: ${response.status} ${response.statusText}`,
+      );
+      const errorData = await response.json();
+      console.error("Error details:", errorData);
+      return null;
+    }
+
+    const data: GitHubTokenResponse = await response.json();
+    return data;
+  } catch (error) {
+    console.error("Error refreshing GitHub access token:", error);
+    return null;
+  }
+}

--- a/apps/api/src/services/user.ts
+++ b/apps/api/src/services/user.ts
@@ -1,8 +1,9 @@
-import { eq } from "drizzle-orm";
+import { eq, and, isNotNull } from "drizzle-orm"; // isNotNull もインポート
 import { users, githubTokens } from "../../drizzle/schema"; // usersとgithubTokensテーブルを直接インポート
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import type * as schema from "../../drizzle/schema";
 import type { GitHubTokenResponse } from "../types/github"; // GitHub関連の型をインポート
+import { refreshGitHubAccessToken } from "./github/auth"; // refreshGitHubAccessToken をインポート
 
 /**
  * GitHubユーザーIDに基づいてユーザーを検索し、存在しない場合は新しく作成する関数。
@@ -101,5 +102,130 @@ export async function saveGitHubTokens(
         ? Math.floor(Date.now() / 1000) + tokens.refresh_token_expires_in
         : undefined,
     });
+  }
+}
+
+/**
+ * 指定されたPrismユーザーIDのGitHubトークン情報をデータベースから取得する関数。
+ * @param db Drizzleデータベースインスタンス
+ * @param userId Prism内部のユーザーID
+ * @returns GitHubトークンレコード、またはnull
+ */
+export async function getGitHubTokensForUser(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+): Promise<typeof githubTokens.$inferSelect | null> {
+  try {
+    const tokens = await db
+      .select()
+      .from(githubTokens)
+      .where(eq(githubTokens.userId, userId))
+      .limit(1);
+
+    if (tokens.length > 0) {
+      return tokens[0];
+    }
+    return null;
+  } catch (error) {
+    console.error(`Error getting GitHub tokens for user ${userId}:`, error);
+    return null;
+  }
+}
+
+/**
+ * 指定されたPrismユーザーIDがGitHubと連携済みかどうかをチェックする関数。
+ * 有効なGitHubトークンがデータベースに存在するかどうかで判断します。
+ * @param db Drizzleデータベースインスタンス
+ * @param userId Prism内部のユーザーID
+ * @returns 連携済みであればtrue、そうでなければfalse
+ */
+export async function isUserGitHubLinked(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+): Promise<boolean> {
+  try {
+    const linkedUser = await db
+      .select()
+      .from(users)
+      .leftJoin(githubTokens, eq(users.id, githubTokens.userId)) // usersとgithubTokensを結合
+      .where(
+        and(
+          // users.idとgithubTokens.userIdが一致し、かつ
+          eq(users.id, userId), // 指定されたuserIdに一致し、かつ
+          isNotNull(githubTokens.accessToken), // githubTokensのaccessTokenが存在する (isNotNullを使用)
+        ),
+      )
+      .limit(1);
+
+    return linkedUser.length > 0; // 結果があれば連携済み
+  } catch (error) {
+    console.error(
+      `Error checking GitHub link status for user ${userId}:`,
+      error,
+    );
+    return false; // エラー時は未連携とみなす
+  }
+}
+
+/**
+ * 指定されたPrismユーザーIDに対して有効なGitHubアクセストークンを取得する関数。
+ * トークンが期限切れの場合、自動的にリフレッシュを試みます。
+ * @param db Drizzleデータベースインスタンス
+ * @param userId Prism内部のユーザーID
+ * @param clientId GitHub AppのクライアントID
+ * @param clientSecret GitHub Appのクライアントシークレット
+ * @returns 有効なアクセストークン、またはnull（取得・リフレッシュ失敗時）
+ */
+export async function getValidGitHubAccessToken(
+  db: DrizzleD1Database<typeof schema>,
+  userId: string,
+  clientId: string,
+  clientSecret: string,
+): Promise<string | null> {
+  const tokenRecord = await getGitHubTokensForUser(db, userId);
+
+  if (!tokenRecord) {
+    console.warn(`No GitHub token record found for user ${userId}.`);
+    return null;
+  }
+
+  // アクセストークンの有効期限が切れているかチェック
+  // 現在時刻 (秒) が有効期限 (秒) を超えているか
+  const currentTimeInSeconds = Math.floor(Date.now() / 1000);
+  const isAccessTokenExpired =
+    tokenRecord.accessTokenExpiresAt <= currentTimeInSeconds;
+
+  if (!isAccessTokenExpired) {
+    // アクセストークンが有効であればそのまま返す
+    return tokenRecord.accessToken;
+  }
+
+  // アクセストークンが期限切れの場合、リフレッシュを試みる
+  if (!tokenRecord.refreshToken) {
+    console.error(
+      `Access token expired for user ${userId}, but no refresh token available.`,
+    );
+    return null;
+  }
+
+  console.log(
+    `Access token expired for user ${userId}. Attempting to refresh...`,
+  );
+  const newTokens = await refreshGitHubAccessToken(
+    tokenRecord.refreshToken,
+    clientId,
+    clientSecret,
+  );
+
+  if (newTokens?.access_token) {
+    // 新しいトークンが取得できたらデータベースを更新
+    await saveGitHubTokens(db, userId, newTokens); // saveGitHubTokensはupsertロジックを持つため、更新も可能
+    console.log(`Access token refreshed and saved for user ${userId}.`);
+    return newTokens.access_token;
+  } else {
+    console.error(
+      `Failed to refresh access token for user ${userId}. User may need to re-authenticate.`,
+    );
+    return null;
   }
 }


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
GitHub APIをたたくためにアクセストークンが必要で、その認証を毎回しなくてよくなるロジックの実装と、アクセストークンが期限切れになっても自動で更新されるロジックの実装。

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->
この実装がないとGitHub APIをたたくたびに認証が必要になる、期限が切れたときにもう一度認証しないといけなくなるから。

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [x] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 依存関係の変更

- [ ] インストールが必要

  インストールコマンド ↓
```pnpm i --frozen-lockfile```

## 📸 スクリーンショット（UI変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->
つぎの作業でGitHub APIを作成し、実際にトークンの取得ができているのかを検証する。

---

## 🔗 関連Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #91 
Closes #65 
Closes #94 
