### PR TITLE
GitHub APIを叩いて、リポジトリ一覧を取得する実装

### DIFF
--- a/apps/api/src/types/github.ts
+++ b/apps/api/src/types/github.ts
@@ -57,3 +57,26 @@ export interface GitHubUserProfile {
   created_at: string;
   updated_at: string;
 }
+
+/**
+ * GitHubのリポジトリ（/user/repos など）レスポンスの主要フィールド。
+ * 参照: https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#list-repositories-for-the-authenticated-user
+ */
+export interface GitHubRepository {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: {
+    login: string;
+    id: number;
+  };
+  html_url: string;
+  description: string | null;
+  default_branch: string;
+  permissions?: {
+    admin?: boolean;
+    push?: boolean;
+    pull?: boolean;
+  };
+}


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか

<!-- 変更内容を簡潔に説明してください -->
GitHub APIを叩いて、リポジトリ一覧を取得する実装をしました。

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->
どのリポジトリにissueを追加するか決める必要があるから。

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [x] プルリクエストにラベルを追加したか
- [x] アサインに自分を追加したか
- [x] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 依存関係の変更

- [ ] インストールが必要

  インストールコマンド ↓
```pnpm i --frozen-lockfile```

## 📸 スクリーンショット（UI変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #50

