### PR TITLE
cookieを拡張機能に適用、過去チャットからメッセージのやり取りを可能に

### DIFF
--- a/apps/api/src/routes/conversation.ts
+++ b/apps/api/src/routes/conversation.ts
@@ -53,6 +53,21 @@ conversations.get("/sessions", async (c) => {
   return c.json({ success: true, data: { sessions } });
 });
 
+conversations.get("/sessions/:sessionId/messages", async (c) => {
+  const userId = c.get("userId");
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+
+  const { sessionId } = c.req.param();
+  const svc = new ConversationService(c.env.GEMINI_API_KEY ?? "", c.env.DB);
+
+  // 所有者チェック
+  const owner = await svc.getSessionOwner(sessionId);
+  if (owner !== userId) return c.json({ error: "Forbidden" }, 403);
+
+  const session = await svc.getSessionData(sessionId);
+  return c.json({ success: true, data: session });
+});
+
 // ヘルスチェック用
 conversations.get("/health", async (c) => {
   return c.json({ status: "ok", service: "conversations" });

--- a/apps/api/src/routes/github.ts
+++ b/apps/api/src/routes/github.ts
@@ -3,11 +3,7 @@ import {
   exchangeCodeForTokens,
   getGitHubUserProfile,
 } from "../services/github/auth"; // getGitHubUserProfileをインポート
-import {
-  findOrCreateUser,
-  saveGitHubTokens,
-  getValidGitHubAccessToken,
-} from "../services/user"; // findOrCreateUser, saveGitHubTokensをインポート
+import { findOrCreateUser, saveGitHubTokens } from "../services/user"; // findOrCreateUser, saveGitHubTokensをインポート
 import type { DrizzleD1Database } from "drizzle-orm/d1";
 import type * as schema from "../../drizzle/schema";
 import type { AppEnv } from "../types/definitions"; // AppEnvをインポート
@@ -150,48 +146,6 @@ githubRouter.get("/callback", async (c) => {
       },
       500,
     );
-  }
-});
-
-// 新規追加: トークン取得とリフレッシュのテストエンドポイント
-githubRouter.get("/test-token-refresh", async (c) => {
-  const db = c.get("db");
-  if (!db) return c.text("Database not initialized.", 500);
-
-  const userId = c.req.query("userId"); // テストしたいユーザーのPrism User IDをクエリパラメータで渡す
-  if (!userId) return c.text("User ID is required for testing.", 400);
-
-  const GITHUB_CLIENT_ID = c.env.GITHUB_CLIENT_ID;
-  const GITHUB_CLIENT_SECRET = c.env.GITHUB_CLIENT_SECRET;
-
-  try {
-    const validAccessToken = await getValidGitHubAccessToken(
-      db,
-      userId,
-      GITHUB_CLIENT_ID,
-      GITHUB_CLIENT_SECRET,
-    );
-
-    if (validAccessToken) {
-      // 取得したトークンを使ってGitHub APIを呼び出してみる (例: /user API)
-      const userProfile = await getGitHubUserProfile(validAccessToken);
-      return c.json({
-        message: "Successfully got valid access token and user profile.",
-        accessToken: validAccessToken,
-        userProfile: userProfile,
-      });
-    } else {
-      return c.json(
-        {
-          message:
-            "Failed to get a valid access token. User may need to re-authenticate.",
-        },
-        401,
-      );
-    }
-  } catch (error) {
-    console.error("Test token refresh endpoint error:", error);
-    return c.json({ error: "Internal server error during token test." }, 500);
   }
 });
 

--- a/apps/api/src/services/conversationsService.ts
+++ b/apps/api/src/services/conversationsService.ts
@@ -321,6 +321,16 @@ export class ConversationService {
     };
   }
 
+  // 他人のsessionIdを使った情報漏洩を防ぐ
+  public async getSessionOwner(sessionId: string): Promise<string | null> {
+    const [row] = await this.db
+      .select({ userId: conversations.userId })
+      .from(conversations)
+      .where(eq(conversations.id, sessionId))
+      .limit(1);
+    return row?.userId ?? null;
+  }
+
   // セッション一覧取得
   async listSessionsByUser(
     userId: string,
@@ -377,6 +387,12 @@ export class ConversationService {
         updatedAt: new Date(c.updatedAt as unknown as number),
       };
     });
+  }
+
+  public async getSessionData(sessionId: string) {
+    const s = await this.getSession(sessionId); // 既存privateを利用
+    if (!s) throw new Error("Session not found");
+    return s; // { id, messages, phase }
   }
 
   // メッセージをDBに保存

--- a/apps/extension/src/background.ts
+++ b/apps/extension/src/background.ts
@@ -40,6 +40,7 @@ chrome.runtime.onMessage.addListener(async (message) => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ code }),
+      credentials: "include",
     });
 
     const data = await response.json();

--- a/apps/extension/src/utils/client.ts
+++ b/apps/extension/src/utils/client.ts
@@ -42,6 +42,7 @@ const requestWithoutBody =
     const response = await fetch(url.toString(), {
       method,
       headers: baseHeaders,
+      credentials: "include", //cookie適用
     });
     return handleResponse<T>(response);
   };
@@ -59,6 +60,7 @@ const requestWithBody =
       method,
       headers: baseHeaders,
       body: data ? JSON.stringify(data) : undefined,
+      credentials: "include",
     });
     return handleResponse<T>(response);
   };


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか
cookieを拡張機能に適用
本人確認しないと履歴・過去のチャット再開ができないよう編集
過去チャットからメッセージのやり取りを可能に
<!-- 変更内容を簡潔に説明してください -->

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->

---

## 🧪 テスト・確認項目

### 動作確認
Set-Cookie: prism_uid=...; SameSite=None; Secureを確認。
本人が履歴チャット一覧を取得で200（未ログインは401）。
本人が履歴チャットアクセスで200、他人は403。
WS接続で作成された会話が自分のuserIdに紐付く。
履歴チャットから再開できる。

<!-- 実際に動作確認した内容を記載してください -->

- [ ] プルリクエストにラベルを追加したか
- [ ] アサインに自分を追加したか
- [ ] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 依存関係の変更

- [ ] インストールが必要

  インストールコマンド ↓
```pnpm i --frozen-lockfile```

## 📸 スクリーンショット（UI変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項
すべてのfetchはcredentials: "include"が必須！
<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #95 
