### PR TITLE
一括Issue作成機能の追加、セッションから生成されたIssueをリポジトリに追加する

### DIFF
--- a/apps/extension/src/components/ModelResponse.tsx
+++ b/apps/extension/src/components/ModelResponse.tsx
@@ -1,6 +1,10 @@
 import { memo, useState } from "react";
 import PrismLogo from "@assets/prism.png";
 import { SelectRepository } from "./SelectRepository";
+import { useCreateIssues } from "@/hooks/api/createIssues";
+import { useGetSessionIssues } from "@/hooks/api/getSessionIssues";
+import { useChatStore } from "@/store/chatStore";
+import type { Repository } from "@/hooks/api/getRepos";
 
 interface ModelResponseProps {
   content: string;
@@ -9,6 +13,11 @@ interface ModelResponseProps {
 export const ModelResponse = memo((props: ModelResponseProps) => {
   const { content } = props;
   const [showRepositorySelection, setShowRepositorySelection] = useState(false);
+  const [isCreatingIssues, setIsCreatingIssues] = useState(false);
+
+  const { createIssues } = useCreateIssues();
+  const { getSessionIssues } = useGetSessionIssues();
+  const sessionId = useChatStore((s) => s.sessionId);
 
   // リポジトリ選択トリガーを検知
   const shouldShowRepositorySelection = content.includes(
@@ -18,10 +27,38 @@ export const ModelResponse = memo((props: ModelResponseProps) => {
   // 表示用のコンテンツ（トリガーコードを除去）
   const displayContent = content.replace("[SHOW_REPOSITORY_SELECTION]\n", "");
 
-  const handleRepositorySelect = (selected: any[]) => {
-    console.log("Selected repositories:", selected);
-    setShowRepositorySelection(false);
-    // TODO: 選択されたリポジトリでIssue登録処理を実行
+  const handleRepositorySelect = async (selected: Repository[]) => {
+    if (selected.length === 0) {
+      setShowRepositorySelection(false);
+      return;
+    }
+
+    if (!sessionId) {
+      alert("セッションが見つかりません。ページをリロードしてください。");
+      setShowRepositorySelection(false);
+      return;
+    }
+
+    setIsCreatingIssues(true);
+    try {
+      // セッションから生成されたIssueを取得
+      const issues = await getSessionIssues(sessionId);
+
+      // 選択された各リポジトリにIssueを作成
+      for (const repository of selected) {
+        await createIssues(repository.fullName, issues);
+      }
+
+      alert(
+        `${selected.length}個のリポジトリに${issues.length}個のIssueを登録しました!`,
+      );
+    } catch (error) {
+      console.error("Issue登録に失敗しました:", error);
+      alert("Issue登録に失敗しました。もう一度お試しください。");
+    } finally {
+      setIsCreatingIssues(false);
+      setShowRepositorySelection(false);
+    }
   };
 
   return (
@@ -37,9 +74,10 @@ export const ModelResponse = memo((props: ModelResponseProps) => {
           <button
             type="button"
             onClick={() => setShowRepositorySelection(true)}
-            className="mt-2 rounded-md bg-[#238636] px-4 py-2 text-sm text-white hover:bg-[#2ea043]"
+            disabled={isCreatingIssues}
+            className="mt-2 rounded-md bg-[#238636] px-4 py-2 text-sm text-white hover:bg-[#2ea043] disabled:opacity-50"
           >
-            リポジトリを選択
+            {isCreatingIssues ? "Issue登録中..." : "リポジトリを選択"}
           </button>
         )}
       </div>

--- a/apps/extension/src/hooks/api/createIssues.ts
+++ b/apps/extension/src/hooks/api/createIssues.ts
@@ -1,0 +1,64 @@
+import { client } from "@/utils/client";
+import { useCallback } from "react";
+
+export interface CreateIssueRequest {
+  title: string;
+  description: string;
+}
+
+export interface CreatedIssue {
+  id: number;
+  number: number;
+  title: string;
+  url: string;
+  html_url: string;
+  state: string;
+}
+
+interface BulkCreateResponse {
+  success: boolean;
+  issues: CreatedIssue[];
+  total: number;
+}
+
+// extension storageからuserIdを取得
+const getUserId = async (): Promise<string> => {
+  const userId = await chrome.storage.local.get("userId");
+  return userId.userId;
+};
+
+// api呼び出し
+const api = (
+  userId: string,
+  owner: string,
+  repo: string,
+  issues: CreateIssueRequest[],
+): Promise<BulkCreateResponse> => {
+  return client.post("github/issues/bulk", {
+    userId,
+    owner,
+    repo,
+    issues,
+  });
+};
+
+/**
+ * Issue一括作成
+ */
+export const useCreateIssues = () => {
+  const createIssues = useCallback(
+    async (
+      repositoryFullName: string,
+      issues: CreateIssueRequest[],
+    ): Promise<CreatedIssue[]> => {
+      const userId = await getUserId();
+      const [owner, repo] = repositoryFullName.split("/");
+
+      const res = await api(userId, owner, repo, issues);
+      return res.issues;
+    },
+    [],
+  );
+
+  return { createIssues };
+};

--- a/apps/extension/src/hooks/api/getSessionIssues.ts
+++ b/apps/extension/src/hooks/api/getSessionIssues.ts
@@ -1,0 +1,32 @@
+import { client } from "@/utils/client";
+import { useCallback } from "react";
+
+export interface GeneratedIssue {
+  title: string;
+  description: string;
+}
+
+// extension storageからuserIdを取得
+const _getUserId = async (): Promise<string> => {
+  const userId = await chrome.storage.local.get("userId");
+  return userId.userId;
+};
+
+const api = (sessionId: string): Promise<{ issues: GeneratedIssue[] }> => {
+  return client.get(`conversation/${sessionId}/issues`);
+};
+
+/**
+ * セッションから生成されたIssue一覧を取得
+ */
+export const useGetSessionIssues = () => {
+  const getSessionIssues = useCallback(
+    async (sessionId: string): Promise<GeneratedIssue[]> => {
+      const res = await api(sessionId);
+      return res.issues;
+    },
+    [],
+  );
+
+  return { getSessionIssues };
+};


### PR DESCRIPTION
## 📝 変更内容

### 何を変更したか
一括Issue作成機能の追加、セッションから生成されたIssueを取得するAPIを実装。リポジトリ選択時にIssueを作成するロジックを追加。
<!-- 変更内容を簡潔に説明してください -->

### なぜ変更したか

<!-- 変更の理由や背景を説明してください -->

---

## 🧪 テスト・確認項目

### 動作確認

<!-- 実際に動作確認した内容を記載してください -->

- [ ] プルリクエストにラベルを追加したか
- [ ] アサインに自分を追加したか
- [ ] ローカル環境で動作確認済み
- [ ] 既存機能に影響がないことを確認
- [ ] モバイル表示を確認（該当する場合）

---

## 依存関係の変更

- [ ] インストールが必要

  インストールコマンド ↓
```pnpm i --frozen-lockfile```

## 📸 スクリーンショット（UI変更がある場合）

<!-- UI変更がある場合は、Before/Afterのスクリーンショットを貼ってください -->

| Before            | After           |
| ----------------- | --------------- |
| ![Before](before) | ![After](after) |

---

## 💡 補足事項

<!-- その他、レビュー時に注意してほしい点や参考情報があれば記載してください -->

---

## 🔗 関連Issue

<!-- 関連するIssueがあれば記載してください -->

Closes #
